### PR TITLE
[splunk-add-on-jira-alerts][#7][Additional Fields]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ local.meta
 *.spl
 
 # Unknown
-build
+build/*
 .build
 *.orig.pre41
 
+### Local Splunk files
+local/*
+metadata/local.meta

--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ find the alert for which you want to add JIRA tickets. Click `Edit`, and select
 for the artifact you wish to create in JIRA when the associated search returns
 results, and Splunk will start logging bugs for you.
 
+NB: To Get the list of Jira Users, the user defined during the setup must have valid permission to access them.
+
 ## Case Study
 For a case study showcasing the application of this custom alert action, see the [Splunk Reference App - PAS](https://github.com/splunk/splunk-ref-pas-code) and the accompanying [Splunk Developer Guidance](http://dev.splunk.com/goto/devguide)
+
+## Splunk alert action tokens
+Please refer to the Splunk Documentation [Developing Views and Apps for Splunk Web](http://docs.splunk.com/Documentation/Splunk/latest/AdvancedDev/ModAlertsLog) to get the list of Token available to customize your Summary and Description fileds..
 
 ## License
 The Splunk Add-on for Atlassian JIRA Alerts is licensed under the Apache License 2.0. Details can be found in the [LICENSE page](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README/alert_actions.conf.spec
+++ b/README/alert_actions.conf.spec
@@ -1,4 +1,53 @@
 [jira]
+* Please refer to the Jira API Documentation for Further Details about Jira Rest API 
+* https://docs.atlassian.com/software/jira/docs/api/REST/7.12.2/?_ga=2.226934429.1412021697.1538460253-230921612.1532996192#api/2/project-getAllProjects
+
 param.jira_url = <string>
+* URL of your Jira instance, example: http://my-jira.example.com:8080
+
 param.jira_username = <string>
+* Username to connect to Jira, require enough privilege to create Issues in the desired Project
+
 param.jira_password = <string>
+* Password associate to your Username. 
+* Setup password will be encrypted in local/password.
+* Override password will NOT be encrypted in the savedsearches.conf
+
+param.project_key = <string>
+* Project Key required to create a Jira Issue. Please refer to your Jira Projects.
+* Related API Call + JQuery Filtering:
+* curl -s -u username:password -X GET 'http://my-jira.example.com:8080/rest/api/2/project' | jq -r '.[]|"\(.name): \(.key)"'
+
+param.issue_type = <string>
+* IssueType Required to create a Jira Issue. Please refer to your Jira IssueTypes.
+* Related API Call + JQuery Filtering:
+* curl -s -u username:password -X GET 'http://my-jira.example.com:8080/rest/api/2/issuetype' | jq -r '.[].name'
+
+param.summary = <string>
+* Custom Alert Summary. [Default associate Splunk Search name: $name$]
+
+param.description = <string>
+* Custom Alert Description. [Default: short message including Splunk Token: $Description$, $name$, $trigger_date$, $trigger_timeHMS$, $results_link$]
+
+param.component = <string>
+* Component related to your Jira Issue.
+* Component are Project Base and can not easily proposed as a list
+
+param.labels = <string>
+* Labels you want to associate your Jira Issue with.
+* Labels must be composed by one word and multiples labels can be separated by ','
+* Example: Splunk2Jira, Test
+
+param.priority = <string>
+* Priority of the Issue [default: Minor (Normal)]
+
+param.timetracking_original = <string> | 10 | 30 | 60 | 90 | 120 | 180
+* Set a Original Time Tracking value [Default: None]
+
+param.assignee = <string>
+* Field to set the assignee, written in the Alert
+* Override param.assignee_list
+
+param.assignee_list = <string>
+* Field to select the Assignee from a list.
+* Is superseded by param.assignee

--- a/README/savedsearches.conf.spec
+++ b/README/savedsearches.conf.spec
@@ -1,7 +1,13 @@
 # JIRA alert settings
 action.jira = [0|1]
+action.jira.param.url_override = <string>
 action.jira.param.project_key = <string>
+action.jira.param.issue_type = <string>
 action.jira.param.summary = <string>
 action.jira.param.description = <string>
-action.jira.param.issue_type = <string>
+action.jira.param.component = <string>
+action.jira.param.labels = <string>
+action.jira.param.priority = <string>
+action.jira.param.timetracking_original = <string>
 action.jira.param.assignee = <string>
+action.jira.param.assignee_list = <string>

--- a/bin/generate_jira_dialog.py
+++ b/bin/generate_jira_dialog.py
@@ -5,6 +5,30 @@ from jira_helpers import *
 TEMPLATE = '''
 <form class="form-horizontal form-complex">
     <div class="control-group">
+        <label class="control-label" for="jira_integration_url">Integration URL</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.jira_url" id="jira_integration_url" />
+            <span class="help-block">Override the global Jira Integration URL (refer to the application setup)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_username">JIRA Username</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.jira_username" id="jira_username" />
+            <span class="help-block">Override the global Jira Username (refer to the application setup)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_password">JIRA Password</label>
+
+        <div class="controls">
+            <input type="password" name="action.jira.param.jira_password" id="jira_password" />
+            <span class="help-block">Override the global Jira Password (will not be encrypted)</span>
+        </div>
+    </div>
+    <div class="control-group">
         <label class="control-label" for="project_key">Project</label>
 
         <div class="controls">
@@ -25,17 +49,7 @@ TEMPLATE = '''
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label" for="jira_priority">Priority</label>
-
-        <div class="controls">
-            <select name="action.jira.param.priority" id="jira_priority">
-                %(priority_choices)s
-            </select>
-            <span class="help-block">Select the issue priority.</span>
-        </div>
-    </div>
-    <div class="control-group">
-        <label class="control-label" for="summary">Summary</label>
+        <label class="control-label" for="summary">Issue Summary</label>
 
         <div class="controls">
             <input type="text" name="action.jira.param.summary" id="summary" />
@@ -54,6 +68,64 @@ TEMPLATE = '''
             </span>
         </div>
     </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_component">Component</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.component" id="jira_component" />
+            <span class="help-block">Override/Set a Component for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_labels">Labels</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.labels" id="jira_labels" />
+            <span class="help-block">Override/Set labels for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_priority">Priority</label>
+
+        <div class="controls">
+            <select name="action.jira.param.priority" id="jira_priority">
+                %(priority_choices)s
+            </select>
+            <span class="help-block">Select the issue priority.</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_timetracking">Original Estimate</label>
+
+        <div class="controls">
+            <select id="jira_timetracking" name="action.jira.param.timetracking_original">
+                <option value=""></option>
+                <option value="10m">10m</option>
+                <option value="20m">20m</option>
+                <option value="30m">30m</option>
+                <option value="60m">60m</option>
+                <option value="90m">90m</option>
+                <option value="120m">180m</option>
+                <option value="180m">180m</option>
+            </select>
+            <span class="help-block">Define an estimate time for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_assignee">Assignee</label>
+
+        <div class="controls">
+            <select name="action.jira.param.assignee_list" id="jira_assignee">
+                <option value=""></option>
+                %(user_choices)s
+            </select>
+            <span class="help-block">Select user to assign the issue (optional)</span>
+        </div>
+        <div class="controls">
+            <input type="text" name="action.jira.param.assignee" id="jira_assignee" />
+            <span class="help-block">Or enter the username (optional - override list choice)</span>
+        </div>
+    </div>
 </form>
 '''
 
@@ -61,7 +133,8 @@ def generate_jira_dialog(jira_settings, server_uri, session_key):
     new_content = TEMPLATE % dict(
         project_choices="\n\t\t".join(map(lambda project: select_choice(value=project.get('key'), label='%(key)s - %(name)s' % project), get_projects(jira_settings))),
         issuetype_choices="\n\t\t".join(map(lambda issuetype: select_choice(value=issuetype.get('name'), label='%(name)s' % issuetype), get_issuetypes(jira_settings))),
-        priority_choices="\n\t\t".join(map(lambda issuetype: select_choice(value=issuetype.get('name'), label='%(name)s' % issuetype), get_priorities(jira_settings))),
+        priority_choices="\n\t\t".join(map(lambda priority: select_choice(value=priority.get('name'), label='%(name)s' % priority), get_priorities(jira_settings))),
+        user_choices="\n\t\t".join(map(lambda users: select_choice(value=users.get('key'), label='%(displayName)s' % users), get_usernames(jira_settings))),
     )
     update_jira_dialog(new_content, server_uri, session_key)
 
@@ -87,6 +160,12 @@ def get_priorities(jira_settings):
         verify=False)
     return response.json()
 
+def get_usernames(jira_settings):
+    response = requests.get(
+        url=jira_url(jira_settings, '/user/search?username=.'),
+        auth=(jira_settings.get('jira_username'), jira_settings.get('jira_password')),
+        verify=False)
+    return response.json()
 
 def select_choice(value, label):
     # TODO: XML escape content

--- a/bin/jira.py
+++ b/bin/jira.py
@@ -12,7 +12,21 @@ def send_message(payload):
     url = config.get('jira_url')
     jira_url = url + ISSUE_REST_PATH
     username = config.get('jira_username')
-    password = get_jira_password(payload.get('server_uri'), payload.get('session_key'))
+    password = config.get('jira_password')
+    if not password:
+        password = get_jira_password(payload.get('server_uri'), payload.get('session_key'))
+    if config.get('component'):
+        component = [ { "name": config.get('component') } ]
+    else:
+        component = []
+    if config.get('labels'):
+        labels = config.get('labels').split(',')
+    else:
+        labels = []
+    if config.get('assignee'):
+        assignee = config.get('assignee')
+    else:
+        assignee = config.get('assignee_list')
 
     # create outbound JSON message body
     body = json.dumps({
@@ -20,10 +34,21 @@ def send_message(payload):
             "project": {
                 "key" : config.get('project_key')
             },
-            "summary": config.get('summary'),
-            "description": config.get('description'),
             "issuetype": {
                 "name": config.get('issue_type')
+            },
+            "summary": config.get('summary'),
+            "description": config.get('description'),
+            "components" : component,
+            "labels": labels,
+            "priority": {
+                "name": config.get('priority')
+            },
+            "timetracking": {
+                "originalEstimate": config.get('timetracking_original')
+            },
+            "assignee": {
+                "name": assignee
             }
         }
     })

--- a/bin/jira_alerts_install_endpoint.py
+++ b/bin/jira_alerts_install_endpoint.py
@@ -17,7 +17,7 @@ class JiraAlertsInstallHandler(admin.MConfigHandler):
     def handleList(self, confInfo):
         jira_settings = get_jira_settings(splunk.getLocalServerInfo(), self.getSessionKey())
         item = confInfo['jira']
-        item['jira_url'] = jira_settings.get('jira_url', 'http://your.server/')
+        item['jira_url'] = jira_settings.get('jira_url', 'http://myjira.example.com:8080/')
         item['jira_username'] = jira_settings.get('jira_username')
         item['jira_password'] = PASSWORD_PLACEHOLDER
         for k in DEFAULT_SETTINGS:

--- a/default/alert_actions.conf
+++ b/default/alert_actions.conf
@@ -5,3 +5,21 @@ label = JIRA
 description = Opens an Issue in JIRA
 icon_path = jira_alert_action.png
 payload_format = json
+
+#Please refer to http://docs.splunk.com/Documentation/Splunk/latest/AdvancedDev/ModAlertsLog
+#for all available token in a Splunk Alert, such as $name$, $result.<field_name>$ , ...
+
+#Default values:
+param.jira_url = http://my-jira.example.com:8080
+param.jira_username = 
+param.jira_password =
+param.project_key = 
+param.summary = $name$
+param.description = $Description$\
+$name$ has been triggered on $trigger_date$ - $trigger_timeHMS$.\
+[Click Here to check the results|$results_link$]
+param.issue_type = Incident
+param.component = 
+param.assignee = 
+param.priority = Minor (Normal)
+param.timetracking_original = 

--- a/default/app.conf
+++ b/default/app.conf
@@ -15,7 +15,7 @@ label = JIRA Custom Alert Action : Ticket Creation
 
 [launcher]
 description = Splunk Add-on for Atlassian JIRA. Includes a custom alert action.
-version = 0.9.0
+version = 0.9.1
 author = Splunk Dev (gmelnik)
 
 [credential::jira_password:]

--- a/default/data/ui/alerts/jira.html
+++ b/default/data/ui/alerts/jira.html
@@ -1,5 +1,29 @@
 <form class="form-horizontal form-complex">
     <div class="control-group">
+        <label class="control-label" for="jira_integration_url">Integration URL</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.jira_url" id="jira_integration_url" />
+            <span class="help-block">Override the global Jira Integration URL (refer to the application setup)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_username">JIRA Username</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.jira_username" id="jira_username" />
+            <span class="help-block">Override the global Jira Username (refer to the application setup)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_password">JIRA Password</label>
+
+        <div class="controls">
+            <input type="password" name="action.jira.param.jira_password" id="jira_password" />
+            <span class="help-block">Override the global Jira Password (refer to the application setup)</span>
+        </div>
+    </div>
+    <div class="control-group">
         <label class="control-label" for="project_key">Project Key</label>
 
         <div class="controls">
@@ -11,7 +35,13 @@
         <label class="control-label" for="issue_type">Issue Type</label>
 
         <div class="controls">
-            <input type="text" name="action.jira.param.issue_type" id="issue_type" />
+            <select id="issue_type" name="action.jira.param.issue_type">
+                <option value="Bug">Bug</option>
+                <option value="Incident">Incident</option>
+                <option value="Support">Support</option>
+                <option value="Task">Task</option>
+                <option value="Access Control">Access Control</option>
+            </select>
             <span class="help-block">Enter an Issue type.</span>
         </div>
     </div>
@@ -33,6 +63,60 @@
                 <a href="{{SPLUNKWEB_URL_PREFIX}}/help?location=learnmore.alert.action.tokens" target="_blank"
                    title="Splunk help">Learn More <i class="icon-external"></i></a>
             </span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_component">Component</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.component" id="jira_component" />
+            <span class="help-block">Override/Set a Component for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_labels">Labels</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.labels" id="jira_labels" />
+            <span class="help-block">Override/Set labels for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_priotiry">Priority</label>
+
+        <div class="controls">
+            <select id="jira_priotiry" name="action.jira.param.priority">
+                <option value="Critical">Critical</option>
+                <option value="Major">Major</option>
+                <option value="Minor (Normal)">Minor (Normal)</option>
+                <option value="Trivial (Rainy Day)">Trivial (Rainy Day)</option>
+            </select>
+            <span class="help-block">Override/Set priority for the issue (Optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_timetracking">Original Estimate</label>
+
+        <div class="controls">
+            <select id="jira_timetracking" name="action.jira.param.timetracking_original">
+                <option value=""></option>
+                <option value="10m">10m</option>
+                <option value="20m">20m</option>
+                <option value="30m">30m</option>
+                <option value="60m">60m</option>
+                <option value="90m">90m</option>
+                <option value="120m">180m</option>
+                <option value="180m">180m</option>
+            </select>
+            <span class="help-block">Define an estimate time for the issue (optional)</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="jira_assignee">Assignee</label>
+
+        <div class="controls">
+            <input type="text" name="action.jira.param.assignee" id="jira_assignee" />
+            <span class="help-block"></span>
         </div>
     </div>
 </form>

--- a/default/setup.xml
+++ b/default/setup.xml
@@ -4,18 +4,20 @@
     </block>
 
     <block title="Server" endpoint="admin/jira_alerts_install" entity="jira">
+        <text>Ensure to set the right URL, and define a valid User/Password with permission to use the Rest API /rest/api/2/issue</text>
         <input field="jira_url">
             <label>Server Base URL</label>
             <type>text</type>
         </input>
         <input field="jira_username">
-            <label>JIRA Username</label>
+            <label>JIRA API Username</label>
             <type>text</type>
         </input>
         <input field="jira_password">
-            <label>JIRA Password</label>
+            <label>JIRA API Password</label>
             <type>password</type>
         </input>
+        <text>Password will be encrypted in Splunk configuration</text>
     </block>
     <block title="Import Projects and Issue Types" endpoint="admin/jira_alerts_install" entity="jira">
         <input field="import">
@@ -31,6 +33,14 @@
         </input>
         <input field="default_issue_type">
             <label>Default Issue Type</label>
+            <type>text</type>
+        </input>
+        <input field="default_component">
+            <label>Default Component</label>
+            <type>text</type>
+        </input>
+        <input field="default_labels">
+            <label>Default Labels</label>
             <type>text</type>
         </input>
         <input field="default_priority">


### PR DESCRIPTION
The Master branch was updated to include the following fields:
- Assignee (as requested in Issue #5)
- Component
- Labels
- Alternate Jira URL/User/Password to override default setup
- Priority field in HTML template
- Original Estime

**Description:**
* Assignee List can be retrieve from Jira if the default User define in Setup has enough privileges.
* Default fields have been added (Component & Label)
* Default values have been set in the fields "Description" & "Summary" to provide examples of Splunk Token.
* Readme has been updated to include new fields and descriptions